### PR TITLE
convert Header component to stateless component

### DIFF
--- a/catch-of-the-day/src/components/Header.js
+++ b/catch-of-the-day/src/components/Header.js
@@ -1,22 +1,19 @@
 import React from 'react';
 
-class Header extends React.Component {
- render() {
-   console.log(this);
-   return (
-     <header className="top">
-       <h1>
-         Catch
-         <span className="ofThe">
+const Header = (props) => {
+  return (
+    <header className="top">
+      <h1>
+        Catch
+        <span className="ofThe">
            <span className="of">of</span>
            <span className="the">the</span>
          </span>
-         Day
-       </h1>
-       <h3 className="tagline"><span>{this.props.tagline}</span></h3>
-     </header>
-   )
- }
-}
+        Day
+      </h1>
+      <h3 className="tagline"><span>{props.tagline}</span></h3>
+    </header>
+  )
+};
 
 export default Header;


### PR DESCRIPTION
Change Header component from ES6 class to a const, since the state will not need to change.